### PR TITLE
Specify language in codeblocks so rouge does have to guess.

### DIFF
--- a/src/integrating-apache-activemq-with-jboss.md
+++ b/src/integrating-apache-activemq-with-jboss.md
@@ -207,7 +207,7 @@ For more information about JCA, please consult the [J2EE Connector Architecture 
 Open the `META-INF/ra.xml` file and look for the following section:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       The URL to the ActiveMQ server that you want this connection to connect to.  If using
@@ -222,7 +222,7 @@ Open the `META-INF/ra.xml` file and look for the following section:
 The section above is used to tell the ActiveMQ RAR where ActiveMQ is located. By default, the in-VM protocol is commented out in favor of the tcp protocol. This will find ActiveMQ running on any interface on the localhost on port 61616. It's ok to just leave this alone if you don't mind the inefficiency of communicating within the JVM via TCP. However, it is recommended that `vm://` transport be used for an embedded broker, so comment out the `tcp://` transport and uncomment the `vm://` transport. Below is an example of this:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       The URL to the ActiveMQ server that you want this connection to connect to.  If using
@@ -239,7 +239,7 @@ Because we're embedding ActiveMQ inside of JBoss, it is more efficient to use th
 Now look further down the `META-INF/ra.xml` file and locate the following section:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       Sets the XML configuration file used to configure the embedded ActiveMQ broker via
@@ -261,7 +261,7 @@ Now look further down the `META-INF/ra.xml` file and locate the following sectio
 The section above needs to be changed to uncomment the second to last line and remove/replace the empty element that is above it. Below is an example of how this should be changed:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       Sets the XML configuration file used to configure the embedded ActiveMQ broker via
@@ -282,7 +282,7 @@ This change tells the ActiveMQ RAR to read a configuration file named `broker-co
 The `broker-config.xml` file _is_ the ActiveMQ configuration file. This is the file used to configure ActiveMQ. The default contents of this file are usable, but should be customized to suit your environment. There are several items of note about this configuration. The most prominent sections to note in this file are the `<persistenceAdapter>` element and the `<transportConnectors>` and `<networkConnectors>` elements as seen below:
 
 `broker-config.xml**
-```
+```xml
 <beans xmlns="http://activemq.org/config/1.0">
 
   <broker useJmx="true">
@@ -313,22 +313,22 @@ The `broker-config.xml` file _is_ the ActiveMQ configuration file. This is the f
 </beans>
 ```
 The first change to this file is to add the brokerName attribute to the broker element and provide a name:
-```
+```xml
 <broker useJmx="true" brokerName="bruce.broker1">
 ```
 In addition, this same name is used further down the configuration to provide a name for the `<transportConnector>` element:
-```
+```xml
 <transportConnector name="bruce.broker1" uri="tcp://localhost:61616" discoveryUri="multicast://default"/>
 ```
 Now we'll tell ActiveMQ not to initialize JMX because we'll use the existing one that JBoss has:
-```
+```xml
 <!-- put the following as the first child of the broker tag -->
 <managementContext><!-- we'll use an existing one (JBoss) instead of creating one -->
   <managementContext createConnector="false"/>
 </managementContext>
 ```
 The `<persistenceAdapter>` element should be reconfigured to store its data in an appropriate place. On JBoss, that's most likely within the "data" directory of the server configuration you're using. We're going to set this dynamically using an XBean and Spring feature that allows us to inject system properties values into the configuration. First this needs to be enabled:
-```
+```xml
 <!-- put the following as the first child of the beans element -->
 <bean xmlns="" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
 ```
@@ -380,7 +380,7 @@ Configuring JBoss
 The sixth step is to configure JBoss to initialize and start ActiveMQ whenever JBoss starts up. This is accomplished using an XML file that abides by the [JBoss JCA DTD](http://www.jboss.org/j2ee/dtd/jboss-ds_1_5.dtd) for data sources. Like most other Java application servers on the market, the JBoss architecture uses the J2EE Connector Architecture to manage connections of any kind including JDBC, JMS, etc. and the JBoss JCA DTD denotes the allowed contents for creating an XML data source instance to configure JBoss JCA. Below is an example XML data source instance for use with JBoss:
 
 `activemq-jms-ds.xml**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE connection-factories

--- a/src/jboss-integration.md
+++ b/src/jboss-integration.md
@@ -207,7 +207,7 @@ For more information about JCA, please consult the [J2EE Connector Architecture 
 Open the `META-INF/ra.xml` file and look for the following section:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       The URL to the ActiveMQ server that you want this connection to connect to.  If using
@@ -222,7 +222,7 @@ Open the `META-INF/ra.xml` file and look for the following section:
 The section above is used to tell the ActiveMQ RAR where ActiveMQ is located. By default, the in-VM protocol is commented out in favor of the tcp protocol. This will find ActiveMQ running on any interface on the localhost on port 61616. It's ok to just leave this alone if you don't mind the inefficiency of communicating within the JVM via TCP. However, it is recommended that `vm://` transport be used for an embedded broker, so comment out the `tcp://` transport and uncomment the `vm://` transport. Below is an example of this:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       The URL to the ActiveMQ server that you want this connection to connect to.  If using
@@ -239,7 +239,7 @@ Because we're embedding ActiveMQ inside of JBoss, it is more efficient to use th
 Now look further down the `META-INF/ra.xml` file and locate the following section:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       Sets the XML configuration file used to configure the embedded ActiveMQ broker via
@@ -261,7 +261,7 @@ Now look further down the `META-INF/ra.xml` file and locate the following sectio
 The section above needs to be changed to uncomment the second to last line and remove/replace the empty element that is above it. Below is an example of how this should be changed:
 
 `META-INF/ra.xml**
-```
+```xml
 <config-property>
     <description>
       Sets the XML configuration file used to configure the embedded ActiveMQ broker via
@@ -282,7 +282,7 @@ This change tells the ActiveMQ RAR to read a configuration file named `broker-co
 The `broker-config.xml` file _is_ the ActiveMQ configuration file. This is the file used to configure ActiveMQ. The default contents of this file are usable, but should be customized to suit your environment. There are several items of note about this configuration. The most prominent sections to note in this file are the `<persistenceAdapter>` element and the `<transportConnectors>` and `<networkConnectors>` elements as seen below:
 
 `broker-config.xml**
-```
+```xml
 <beans xmlns="http://activemq.org/config/1.0">
 
   <broker useJmx="true">
@@ -313,22 +313,22 @@ The `broker-config.xml` file _is_ the ActiveMQ configuration file. This is the f
 </beans>
 ```
 The first change to this file is to add the brokerName attribute to the broker element and provide a name:
-```
+```xml
 <broker useJmx="true" brokerName="bruce.broker1">
 ```
 In addition, this same name is used further down the configuration to provide a name for the `<transportConnector>` element:
-```
+```xml
 <transportConnector name="bruce.broker1" uri="tcp://localhost:61616" discoveryUri="multicast://default"/>
 ```
 Now we'll tell ActiveMQ not to initialize JMX because we'll use the existing one that JBoss has:
-```
+```xml
 <!-- put the following as the first child of the broker tag -->
 <managementContext><!-- we'll use an existing one (JBoss) instead of creating one -->
   <managementContext createConnector="false"/>
 </managementContext>
 ```
 The `<persistenceAdapter>` element should be reconfigured to store its data in an appropriate place. On JBoss, that's most likely within the "data" directory of the server configuration you're using. We're going to set this dynamically using an XBean and Spring feature that allows us to inject system properties values into the configuration. First this needs to be enabled:
-```
+```xml
 <!-- put the following as the first child of the beans element -->
 <bean xmlns="" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
 ```
@@ -380,7 +380,7 @@ Configuring JBoss
 The sixth step is to configure JBoss to initialize and start ActiveMQ whenever JBoss starts up. This is accomplished using an XML file that abides by the [JBoss JCA DTD](http://www.jboss.org/j2ee/dtd/jboss-ds_1_5.dtd) for data sources. Like most other Java application servers on the market, the JBoss architecture uses the J2EE Connector Architecture to manage connections of any kind including JDBC, JMS, etc. and the JBoss JCA DTD denotes the allowed contents for creating an XML data source instance to configure JBoss JCA. Below is an example XML data source instance for use with JBoss:
 
 `activemq-jms-ds.xml**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE connection-factories

--- a/src/jms-to-jms-bridge.md
+++ b/src/jms-to-jms-bridge.md
@@ -115,7 +115,7 @@ outboundQueueName|null|the foreign queue name to send to
 ### Example XBean Configuration
 
 The following [example config file](http://svn.apache.org/repos/asf/activemq/trunk/activemq-unit-tests/src/test/resources/org/apache/activemq/network/jms/queue-xbean.xml) shows how to use the regular [Xml Configuration](xml-configuration) to configure a JMS to JMS bridge.
-```
+```xml
 <broker xmlns="http://activemq.apache.org/schema/core" id="localbroker"
   brokerName="localBroker" persistent="false">
   <jmsBridgeConnectors>
@@ -141,7 +141,7 @@ The following [example config file](http://svn.apache.org/repos/asf/activemq/tru
 ### Example pure Spring Configuration
 
 The following example shows how to use raw Spring XML to wire together a broker - bridging to a Foreign JMS provider
-```
+```xml
 <!-- local broker with embedded Jms to Jms bridge (ok - it's contrived) -->
 <bean id="localbroker" class="org.apache.activemq.broker.BrokerService"
   init-method="start">
@@ -186,7 +186,7 @@ The following example shows how to use raw Spring XML to wire together a broker 
 ### Example XBean Configuration to Bridge ActiveMQ to Provider With No URL Setter
 
 Some JMS providers, WebLogic for instance, do not expose a setter for connection properties like host and port (setBrokerUrl) on their ConnectionFactory object. In this case you need to set outboundQueueConnectionFactoryName and jndiOutboundTemplate in your activemq.xml config file.
-```
+```xml
 <!-- START SNIPPET: example -->
 <beans>
 
@@ -246,7 +246,7 @@ Some JMS providers, WebLogic for instance, do not expose a setter for connection
 ### Example pure Spring Configuration for sending messages to external ActiveMQ destination through bridge
 
 Spring beans:
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 

--- a/src/sjsas-with-genericjmsra.md
+++ b/src/sjsas-with-genericjmsra.md
@@ -68,7 +68,7 @@ genericra.rar
 mymodules.jar
 ```
 Inside the mymodules.jar (where I put my MDB), the sun-ejb-jar.xml should look like this:
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE sun-ejb-jar
   PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 8.1 EJB 2.1//EN"
@@ -98,7 +98,7 @@ Inside the mymodules.jar (where I put my MDB), the sun-ejb-jar.xml should look l
 </sun-ejb-jar>
 ```
 And the application.xml should look like this:
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <application
     xmlns="http://java.sun.com/xml/ns/javaee"

--- a/src/weblogic-integration.md
+++ b/src/weblogic-integration.md
@@ -151,7 +151,7 @@ This section discusses the code, libraries, and configuration files necessary to
 ActiveMQ needs to start when the web application is deployed or started, and stop when the web application is stopped or undeployed. The easiest way to do this is to a use the commonly available Spring listeners, which start a Spring context, which can point ActiveMQ to an XBean configuration file, which starts ActiveMQ. A little roundabout, but it works well in practice with very little configuration.
 
 **J2EE WEB-INF/web.xml**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 
 <web-app version="2.4"
@@ -164,7 +164,7 @@ ActiveMQ needs to start when the web application is deployed or started, and sto
 </web-app>
 ```
 **Spring WEB-INF/applicationContext.xml**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
 <beans>
@@ -365,7 +365,7 @@ This section shows three sample ActiveMQ configuration files – one for a singl
 It also shows a Log4J configuration file, which controls the ActiveMQ log output.
 
 **Single Broker**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://activemq.org/config/1.0">
   <!-- Allows us to use system properties as variables in this configuration file -->
@@ -421,7 +421,7 @@ It also shows a Log4J configuration file, which controls the ActiveMQ log output
 ```
 
 **Network of Brokers (Broker 1/2)**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://activemq.org/config/1.0">
   <!-- Allows us to use system properties as variables in this configuration file -->
@@ -483,7 +483,7 @@ It also shows a Log4J configuration file, which controls the ActiveMQ log output
 ```
 
 **Network of Brokers (Broker 2/2)**
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://activemq.org/config/1.0">
   <!-- Allows us to use system properties as variables in this configuration file -->


### PR DESCRIPTION
When building with the official container `jekyll/jekyll:4` the build results in the error

```
/usr/gem/gems/rouge-3.11.1/lib/rouge/lexer.rb:178:in `guess': Ambiguous guess: can't decide between ["xml", "mason"] (Rouge::Guesser::Ambiguous)
```

This PR adds a language specifier to code blocks with XML content to help rouge decide.