### PR TITLE
Fixed broken links in contributing.md file

### DIFF
--- a/content/contributing.html
+++ b/content/contributing.html
@@ -121,7 +121,7 @@ e.g. take a look at some of the existing <a href="https://git-wip-us.apache.org/
 
 <h2 id="if-you-want-to-help-out-with-the-documentation">If you want to help out with the documentation</h2>
 
-<p>If you want to contribute to the ActiveMQ documentation you should first subscribe our <a href="mailto:dev-subscribe@activemq.apache.org">dev@</a> where ActiveMQ developers interact with each other. If you want edit rights on the ActiveMQ site, create an account in the <a href="https://cwiki.apache.org/confluence/display/ACTIVEMQ">ActiveMQ wiki</a> and fill in and submit an ICLA to the ASF (see the <a href="Developers/becoming-a-committer.md">Committer Guide</a>). Then ask on the dev@ list to be granted edit rights and an admin will do so fairly quickly. If you want to just contribute the content, please submit the content on the dev@ list or create an issue and attach it there. <strong>All</strong> contributions are highly appreciated.</p>
+<p>If you want to contribute to the ActiveMQ documentation you should first subscribe our <a href="mailto:dev-subscribe@activemq.apache.org">dev@</a> where ActiveMQ developers interact with each other. If you want edit rights on the ActiveMQ site, create an account in the <a href="https://cwiki.apache.org/confluence/display/ACTIVEMQ">ActiveMQ wiki</a> and fill in and submit an ICLA to the ASF (see the <a href="becoming-a-committer">Committer Guide</a>). Then ask on the dev@ list to be granted edit rights and an admin will do so fairly quickly. If you want to just contribute the content, please submit the content on the dev@ list or create an issue and attach it there. <strong>All</strong> contributions are highly appreciated.</p>
 
 <h2 id="working-on-the-code">Working on the code</h2>
 
@@ -153,11 +153,11 @@ mvn -Dtest=false install
 
 <h2 id="submitting-patches">Submitting patches</h2>
 
-<p>The easiest way to submit a patch is to create a new JIRA issue, attach the patch and tick the ASF license grant check box, tick the Patch Attached button on the issue then fire off an email to the <a href="Community/mailing-lists.md">Mailing Lists</a> or <a href="CommunityCommunity/Community/discussion-forums.md">Discussion Forums</a>.</p>
+<p>The easiest way to submit a patch is to create a new JIRA issue, attach the patch and tick the ASF license grant check box, tick the Patch Attached button on the issue then fire off an email to the <a href="mailing-lists">Mailing Lists</a> or <a href="discussion-forums">Discussion Forums</a>.</p>
 
 <h2 id="becoming-a-commmitter">Becoming a commmitter</h2>
 
-<p>Once you’ve got involved as above, we may well invite you to be a committer. See <a href="Developers/becoming-a-committer.md">Becoming a committer</a> for more details.</p>
+<p>Once you’ve got involved as above, we may well invite you to be a committer. See <a href="becoming-a-committer">Becoming a committer</a> for more details.</p>
 
 <h2 id="using-the-issue-tracker">Using the issue tracker</h2>
 
@@ -169,8 +169,7 @@ mvn -Dtest=false install
 
 <h2 id="becoming-a-committer">Becoming a committer</h2>
 
-<p>The first step is contributing to the project; if you want to take that a step forward and become a fellow committer on the project then see the <a href="Developers/becoming-a-committer.md">Committer Guide</a></p>
-
+<p>The first step is contributing to the project; if you want to take that a step forward and become a fellow committer on the project then see the <a href="becoming-a-committer">Committer Guide</a></p>
 
       </div>
     </div>

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -36,7 +36,7 @@ Then we can add your issue to the test suite and then we'll know when its really
 If you want to help out with the documentation
 ----------------------------------------------
 
-If you want to contribute to the ActiveMQ documentation you should first subscribe our [dev@](mailto:dev-subscribe@activemq.apache.org) where ActiveMQ developers interact with each other. If you want edit rights on the ActiveMQ site, create an account in the [ActiveMQ wiki](https://cwiki.apache.org/confluence/display/ACTIVEMQ) and fill in and submit an ICLA to the ASF (see the [Committer Guide](Developers/becoming-a-committer.md)). Then ask on the dev@ list to be granted edit rights and an admin will do so fairly quickly. If you want to just contribute the content, please submit the content on the dev@ list or create an issue and attach it there. **All** contributions are highly appreciated.
+If you want to contribute to the ActiveMQ documentation you should first subscribe our [dev@](mailto:dev-subscribe@activemq.apache.org) where ActiveMQ developers interact with each other. If you want edit rights on the ActiveMQ site, create an account in the [ActiveMQ wiki](https://cwiki.apache.org/confluence/display/ACTIVEMQ) and fill in and submit an ICLA to the ASF (see the [Committer Guide](becoming-a-committer)). Then ask on the dev@ list to be granted edit rights and an admin will do so fairly quickly. If you want to just contribute the content, please submit the content on the dev@ list or create an issue and attach it there. **All** contributions are highly appreciated.
 
 Working on the code
 -------------------
@@ -75,12 +75,12 @@ git diff Main.java >> patchfile.txt
 Submitting patches
 ------------------
 
-The easiest way to submit a patch is to create a new JIRA issue, attach the patch and tick the ASF license grant check box, tick the Patch Attached button on the issue then fire off an email to the [Mailing Lists](Community/mailing-lists.md) or [Discussion Forums](CommunityCommunity/Community/discussion-forums.md).
+The easiest way to submit a patch is to create a new JIRA issue, attach the patch and tick the ASF license grant check box, tick the Patch Attached button on the issue then fire off an email to the [Mailing Lists](mailing-lists) or [Discussion Forums](discussion-forums).
 
 Becoming a commmitter
 ---------------------
 
-Once you've got involved as above, we may well invite you to be a committer. See [Becoming a committer](Developers/becoming-a-committer.md) for more details.
+Once you've got involved as above, we may well invite you to be a committer. See [Becoming a committer](becoming-a-committer) for more details.
 
 Using the issue tracker
 -----------------------
@@ -94,5 +94,4 @@ Why not dive in the [issue tracker](https://issues.apache.org/jira/browse/AMQ), 
 Becoming a committer
 --------------------
 
-The first step is contributing to the project; if you want to take that a step forward and become a fellow committer on the project then see the [Committer Guide](Developers/becoming-a-committer.md)
-
+The first step is contributing to the project; if you want to take that a step forward and become a fellow committer on the project then see the [Committer Guide](becoming-a-committer)


### PR DESCRIPTION
- These pages lead to a 404:
https://activemq.apache.org/Developers/becoming-a-committer.md
https://activemq.apache.org/CommunityCommunity/Community/discussion-forums.md

---
![image](https://user-images.githubusercontent.com/30496180/74021478-a1c85d00-49c1-11ea-9b50-0baa94b6a17c.png)
---
![image](https://user-images.githubusercontent.com/30496180/74021483-a4c34d80-49c1-11ea-9bac-f9fbd79948a3.png)
---

- Broken links exist on this page - https://activemq.apache.org/contributing

