### PR TITLE
Remove broken download and changelog links

### DIFF
--- a/src/activemq-11-release.md
+++ b/src/activemq-11-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-11-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 1.1 Release](activemq-11-release)
 
 New and Noteworthy
 ------------------
@@ -23,21 +23,3 @@ This release represents a major increase in functionality; the new features in t
 *   composite destinations support (allowing a publish or subscribe operation on several queues and/or topics in one atomic operation, such as writing to N queues in one operation)
 *   simpler pure-Java configuration API
 *   heaps of bug fixes and new test cases
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-1.1.zip](http://dist.codehaus.org/activemq/distributions/activemq-1.1.zip)|Binary Distribution in zip package
-[activemq-1.1-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-1.1-src.zip)|Source Distribution in zip package
-[activemq-1.1.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-1.1.tar.gz)|Binary Distribution in gz package
-[activemq-1.1-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-1.1-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?projectId=10520&styleName=Html&version=10632)
-

--- a/src/activemq-12-release.md
+++ b/src/activemq-12-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-12-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 1.2 Release](activemq-12-release)
 
 New and Noteworthy
 ------------------
@@ -13,23 +13,3 @@ New and Noteworthy
 This release represents a major increase in functionality; the new features in this release are:-
 
 *   heaps of bug fixes and new test cases
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-1.2.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.2.zip)|Binary Distribution in zip package
-[activemq-release-1.2-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.2-src.zip)|Source Distribution in zip package
-[activemq-release-1.2.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.2.tar.gz)|Binary Distribution in gz package
-[activemq-release-1.2-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.2-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11120&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-11-release)
-

--- a/src/activemq-13-release.md
+++ b/src/activemq-13-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-13-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 1.3 Release](activemq-13-release)
 
 New and Noteworthy
 ------------------
@@ -13,23 +13,3 @@ New and Noteworthy
 This release represents a major increase in functionality; the new features in this release are:-
 
 *   heaps of bug fixes and new test cases
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-1.3.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.3.zip)|Binary Distribution in zip package
-[activemq-release-1.3-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.3-src.zip)|Source Distribution in zip package
-[activemq-release-1.3.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.3.tar.gz)|Binary Distribution in gz package
-[activemq-release-1.3-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.3-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11270&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-12-release)
-

--- a/src/activemq-14-release.md
+++ b/src/activemq-14-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-14-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 1.4 Release](activemq-14-release)
 
 New and Noteworthy
 ------------------
@@ -13,23 +13,3 @@ New and Noteworthy
 This release represents a major increase in functionality; the new features in this release are:-
 
 *   heaps of bug fixes and new test cases
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-1.4.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.4.zip)|Binary Distribution in zip package
-[activemq-release-1.4-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.4-src.zip)|Source Distribution in zip package
-[activemq-release-1.4.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.4.tar.gz)|Binary Distribution in gz package
-[activemq-release-1.4-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.4-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11390&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-13-release)
-

--- a/src/activemq-15-release.md
+++ b/src/activemq-15-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-15-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 1.5 Release](activemq-15-release)
 
 New and Noteworthy
 ------------------
@@ -13,23 +13,3 @@ New and Noteworthy
 This release is mostly a bug fix release:-
 
 *   A few bug fixes for J2EE compliance
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-1.5.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.5.zip)|Binary Distribution in zip package
-[activemq-release-1.5-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-1.5-src.zip)|Source Distribution in zip package
-[activemq-release-1.5.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.5.tar.gz)|Binary Distribution in gz package
-[activemq-release-1.5-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-1.5-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11422&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-14-release)
-

--- a/src/activemq-20-release.md
+++ b/src/activemq-20-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-20-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 2.0 Release](activemq-20-release)
 
 New and Noteworthy
 ------------------
@@ -26,23 +26,3 @@ This release includes
 *   improvements in the JCA Resource Adapter for easier integration into Geronimo, JBoss and WebLogic
 
 This new 2.0 wire format is incompatible with previous releases, so when upgrading please be sure to upgrade across your system. The wire format should not change now for some time, certainly not until another major release.
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-2.0.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-2.0.zip)|Binary Distribution in zip package
-[activemq-release-2.0-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-2.0-src.zip)|Source Distribution in zip package
-[activemq-release-2.0.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-2.0.tar.gz)|Binary Distribution in gz package
-[activemq-release-2.0-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-2.0-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11420&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-15-release)
-

--- a/src/activemq-21-release.md
+++ b/src/activemq-21-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-21-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 2.1 Release](activemq-21-release)
 
 New and Noteworthy
 ------------------
@@ -13,23 +13,3 @@ New and Noteworthy
 This release includes full support for the high performance journal. Our default persistence mechanism is now the journal for short term persistence and then JDBC (via Apache Derby by default) for long term storage. The journal is regularly checkpointed with the database for high performance and high resiliency.
 
 This new release includes a number of performance enhancements in both durable and non durable messaging as well as a number of bug fixes.
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-2.1.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-2.1.zip)|Binary Distribution in zip package
-[activemq-release-2.1-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-2.1-src.zip)|Source Distribution in zip package
-[activemq-release-2.1.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-2.1.tar.gz)|Binary Distribution in gz package
-[activemq-release-2.1-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-2.1-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11499&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-20-release)
-

--- a/src/activemq-30-release.md
+++ b/src/activemq-30-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-30-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 3.0 Release](activemq-30-release)
 
 New and Noteworthy
 ------------------
@@ -18,21 +18,3 @@ This new release includes the following
 *   an optimised wire protocol (which is unfortunately not compatible with 2.x)
 *   more test cases and fixes of the [JCA Container](jca-container)
 *   various performance enhancements and bug fixes
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-3.0.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.0.zip)|Binary Distribution in zip package
-[activemq-release-3.0-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.0-src.zip)|Source Distribution in zip package
-[activemq-release-3.0.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.0.tar.gz)|Binary Distribution in gz package
-[activemq-release-3.0-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.0-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11500&styleName=Html&projectId=10520&Create=Create)
-
-You may also want to look at [the previous Changelog](activemq-21-release)
-

--- a/src/activemq-31-release.md
+++ b/src/activemq-31-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-31-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 3.1 Release](activemq-31-release)
 
 New and Noteworthy
 ------------------
@@ -35,21 +35,3 @@ This new release includes the following
 *   easier journal file size and checkpoint period configuration
 *   jabber transport
 *   various performance enhancements and bug fixes
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-3.1.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.1.zip)|Binary Distribution in zip package
-[activemq-release-3.1-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.1-src.zip)|Source Distribution in zip package
-[activemq-release-3.1.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.1.tar.gz)|Binary Distribution in gz package
-[activemq-release-3.1-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.1-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11501&styleName=Html&projectId=10520&Create=Create)
-
-You may also want to look at [the previous Changelog](activemq-30-release)
-

--- a/src/activemq-32-release.md
+++ b/src/activemq-32-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-32-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 3.2 Release](activemq-32-release)
 
 New and Noteworthy
 ------------------
@@ -19,21 +19,3 @@ This new release includes the following
 *   support for Informix JDBC
 *   updated DTD for the latest Spring
 *   various performance enhancements and bug fixes
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-3.2.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.2.zip)|Binary Distribution in zip package
-[activemq-release-3.2-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-3.2-src.zip)|Source Distribution in zip package
-[activemq-release-3.2.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.2.tar.gz)|Binary Distribution in gz package
-[activemq-release-3.2-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-3.2-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](https://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11610&styleName=Html&projectId=10520&Create=Create)
-
-You may also want to look at [the previous Changelog](activemq-31-release)
-

--- a/src/activemq-321-release.md
+++ b/src/activemq-321-release.md
@@ -11,21 +11,3 @@ New and Noteworthy
 ------------------
 
 This release is a bug fix release and users of previous versions of 3.2 are encouraged to upgrade to this version.
-
-Download Here
--------------
-
-Download|Description
-[activemq-3.2.1.zip](http://dist.codehaus.org/activemq/distributions/activemq-3.2.1.zip)|Binary Distribution in zip package
-[activemq-3.2.1-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-3.2.1-src.zip)|Source Distribution in zip package
-[activemq-3.2.1.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-3.2.1.tar.gz)|Binary Distribution in gz package
-[activemq-3.2.1-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-3.2.1-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](https://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11715&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-32-release)

--- a/src/activemq-322-release.md
+++ b/src/activemq-322-release.md
@@ -11,22 +11,3 @@ New and Noteworthy
 ------------------
 
 This release is a bug fix release and users of previous versions of 3.2 are encouraged to upgrade to this version.
-
-Download Here
--------------
-
-Download|Description
-[activemq-3.2.2.zip](http://dist.codehaus.org/activemq/distributions/activemq-3.2.2.zip)|Binary Distribution in zip package
-[activemq-3.2.2-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-3.2.2-src.zip)|Source Distribution in zip package
-[activemq-3.2.2.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-3.2.2.tar.gz)|Binary Distribution in gz package
-[activemq-3.2.2-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-3.2.2-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?version=11723&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-You may also want to look at [the previous Changelog](activemq-321-release)
-

--- a/src/activemq-40-m4-release.md
+++ b/src/activemq-40-m4-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-40-m4-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 4.0-m4 Release](activemq-40-m4-release)
 
 New and Noteworthy
 ------------------
@@ -13,18 +13,3 @@ New and Noteworthy
 This is the first milestone release of 4.x since the move to Apache so the package names have changed from org.activemq to org.apache.activemq. For a full list see the [Changes in 4.0](changes-in-40).
 
 This release of ActiveMQ includes a large number of [new features](changes-in-40) such as [MasterSlave](masterslave) and [Message Groups](message-groups) together with numerous bug fixes.
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-4.0-M4.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-M4.zip)|Binary Distribution in zip package
-[activemq-release-4.0-M4-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-M4-src.zip)|Source Distribution in zip package
-[activemq-release-4.0-M4.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-M4.tar.gz)|Binary Distribution in gz package
-[activemq-release-4.0-M4-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-M4-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://jira.activemq.org/jira/secure/ReleaseNote.jspa?projectId=10520&styleName=Html&version=11726)

--- a/src/activemq-40-rc2-release.md
+++ b/src/activemq-40-rc2-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-40-rc2-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 4.0-rc2 Release](activemq-40-rc2-release)
 
 New and Noteworthy
 ------------------
@@ -21,21 +21,3 @@ When upgrading from a previous release you are advised to clear down the journal
 ### What has changed
 
 The 4.x branch of ActiveMQ has now moved to the Apache Incubator so the package names have changed from org.activemq to org.apache.activemq. For a full list see the [Changes in 4.0](New FeaturesFeatures/New Features/Features/New Features/changes-in-40).
-
-Download Here
--------------
-
-Download|Description
----|---
-[activemq-release-4.0-RC2.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-RC2.zip)|Binary Distribution in zip package
-[activemq-release-4.0-RC2-src.zip](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-RC2-src.zip)|Source Distribution in zip package
-[activemq-release-4.0-RC2.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-RC2.tar.gz)|Binary Distribution in gz package
-[activemq-release-4.0-RC2-src.tar.gz](http://dist.codehaus.org/activemq/distributions/activemq-release-4.0-RC2-src.tar.gz)|Source Distribution in gz package
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/activemq/secure/ReleaseNote.jspa?projectId=10520&styleName=Html&version=11750)
-
-Also see the previous [ActiveMQ 4.0 M4 Release](activemq-40-m4-release)
-

--- a/src/activemq-40-release.md
+++ b/src/activemq-40-release.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
-[Overview](overview) > [Download](download) > [ActiveMQ 3.2.1 Release](activemq-40-release)
+[Overview](overview) > [Download](download) > [ActiveMQ 4.0 Release](activemq-40-release)
 
 New and Noteworthy
 ------------------
@@ -33,26 +33,8 @@ patch -p 0 < ${path-to-amq4-build.patch}
 
 The 4.x branch of Apache ActiveMQ has now moved to the Apache Incubator so the package names have changed from org.activemq to org.apache.activemq. For a full list see the [Changes in 4.0](New FeaturesFeatures/New Features/Features/New Features/changes-in-40).
 
-Download Here
--------------
-
-Download|Description
----|---
-[incubator-activemq-4.0.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.zip)|Binary Distribution in zip package
-[incubator-activemq-4.0-src.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0-src.zip)|Source Distribution in zip package
-[incubator-activemq-4.0.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.tar.gz)|Binary Distribution in gz package
-[incubator-activemq-4.0-src.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0-src.tar.gz)|Source Distribution in gz package
-
 SVN Tag Checkout
 ----------------
 ```
 svn co https://svn.apache.org/repos/asf/incubator/activemq/tags/activemq-4.0
 ```
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://issues.apache.org/activemq/secure/IssueNavigator.jspa?reset=true&pid=10520&fixfor=11660)
-
-Also see the previous [ActiveMQ 4.0 RC2 Release](activemq-40-rc2-release)
-

--- a/src/activemq-401-release.md
+++ b/src/activemq-401-release.md
@@ -13,27 +13,7 @@ New and Noteworthy
 
 This is a minor bug fix release. All previous installations of Apache ActiveMQ 4.0 are recommended to upgrade to this release.
 
-Download Here
--------------
-
-Description|Download Link|PGP Signature file of download
----|---|---
-Binary for Windows|[incubator-activemq-4.0.1.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1.zip)|[incubator-activemq-4.0.1.zip.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1.zip.asc)
-Source code for Windows|[incubator-activemq-4.0.1-src.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1-src.zip)|[incubator-activemq-4.0.1-src.zip.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1-src.zip.asc)
-Binary for Unix|[incubator-activemq-4.0.1.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1.tar.gz)|[incubator-activemq-4.0.1.tar.gz.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1.tar.gz.asc)
-Source code for Unix|[incubator-activemq-4.0.1-src.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1-src.tar.gz)|[incubator-activemq-4.0.1-src.tar.gz.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.1-src.tar.gz.asc)
-
 SVN Tag Checkout
 ----------------
 
 svn co https://svn.apache.org/repos/asf/incubator/activemq/tags/activemq-4.0.1
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://issues.apache.org/activemq/secure/ReleaseNote.jspa?version=11780&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-Also see the previous [ActiveMQ 4.0 Release](activemq-40-release)
-

--- a/src/activemq-402-release.md
+++ b/src/activemq-402-release.md
@@ -11,27 +11,7 @@ type: activemq5
 
 This is a minor bug fix release. All previous installations of Apache ActiveMQ 4.0.1 are recommended to upgrade to this release.
 
-Download Here
--------------
-
-Description|Download Link|PGP Signature file of download
----|---|---
-Binary for Windows|[incubator-activemq-4.0.2.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2.zip)|[incubator-activemq-4.0.2.zip.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2.zip.asc)
-Source code for Windows|[incubator-activemq-4.0.2-src.zip](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2-src.zip)|[incubator-activemq-4.0.2-src.zip.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2-src.zip.asc)
-Binary for Unix|[incubator-activemq-4.0.2.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2.tar.gz)|[incubator-activemq-4.0.2.tar.gz.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2.tar.gz.asc)
-Source code for Unix|[incubator-activemq-4.0.2-src.tar.gz](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2-src.tar.gz)|[incubator-activemq-4.0.2-src.tar.gz.asc](http://people.apache.org/repository/incubator-activemq/distributions/incubator-activemq-4.0.2-src.tar.gz.asc)
-
 SVN Tag Checkout
 ----------------
 
 svn co https://svn.apache.org/repos/asf/incubator/activemq/tags/activemq-4.0.2 
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://issues.apache.org/activemq/secure/ReleaseNote.jspa?version=11783&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-Also see the previous [ActiveMQ 4.0.1 Release](activemq-401-release)
-

--- a/src/activemq-410-release.md
+++ b/src/activemq-410-release.md
@@ -20,25 +20,6 @@ This is release contains several major enhancements such as:
 
 It also contains a slew of bug fixes that are tracked in the change log.
 
-Download Here
--------------
-
-Description|Download Link|PGP Signature file of download
----|---|---
-Binary for Windows|[apache-activemq-4.1.0-incubator.zip](http://people.apache.org/repo/m2-incubating-repository/org/apache/activemq/apache-activemq/4.1.0-incubator/apache-activemq-4.1.0-incubator.zip)|[incubator-activemq-4.1.0.zip.asc](http://people.apache.org/repo/m2-incubating-repository/org/apache/activemq/apache-activemq/4.1.0-incubator/apache-activemq-4.1.0-incubator.zip.asc)
-Binary for Unix/Linux/Cygwin|[apache-activemq-4.1.0-incubator.tar.gz](http://people.apache.org/repo/m2-incubating-repository/org/apache/activemq/apache-activemq/4.1.0-incubator/apache-activemq-4.1.0-incubator.tar.gz)|[incubator-activemq-4.1.0.tar.gz.asc](http://people.apache.org/repo/m2-incubating-repository/org/apache/activemq/apache-activemq/4.1.0-incubator/apache-activemq-4.1.0-incubator.tar.gz.asc)
-
 SVN Tag Checkout
 ----------------
-
 svn co https://svn.apache.org/repos/asf/activemq/tags/activemq-4.1.0 
-
-Changelog
----------
-
-For a more detailed view of new features and bug fixes, see the [release notes](http://issues.apache.org/activemq/secure/ReleaseNote.jspa?version=11691&styleName=Html&projectId=10520&Create=Create)
-
-JIRA Issues Macro: Unable to locate JIRA server for this macro. It may be due to Application Link configuration.
-
-Also see the previous [ActiveMQ 4.0.2 Release](activemq-402-release)
-


### PR DESCRIPTION
As discussed with JB on slack, removed broken download links and changelogs for versions 4.1.0 and older which don't seem to be available on http://archive.apache.org/dist/activemq/apache-activemq/. I also noticed the breadcrumbs all referenced version 3.2.1 for these old versions. 