### PR TITLE
Update documentation to reflect authorizationEntry for all groups  in…

### DIFF
--- a/src/security.md
+++ b/src/security.md
@@ -111,7 +111,7 @@ To control access to temporary destinations, you will need to add a `<tempDestin
           <authorizationMap> 
             <authorizationEntries> 
               <authorizationEntry queue="TEST.Q" read="users" write="users" admin="users" /> 
-              <authorizationEntry topic="ActiveMQ.Advisory.>" read="all" write="all" admin="all"/> 
+              <authorizationEntry topic="ActiveMQ.Advisory.>" read="*" write="*" admin="*"/> 
             </authorizationEntries> 
             <tempDestinationAuthorizationEntry> 
               <tempDestinationAuthorizationEntry read="admin" write="admin" admin="admin"/> 


### PR DESCRIPTION
Fixing authorizationEntry documentation
Following line in the security.md is misleading and does not apply the change
```
<authorizationEntry topic="ActiveMQ.Advisory.>" read="all" write="all" admin="all"/> 
```
instead the following update in the documentation is proposed which actually works,
```
<authorizationEntry topic="ActiveMQ.Advisory.>" read="*" write="*" admin="*"/> 
```

