### PR TITLE
make news page styling consistent with other general pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,8 +64,8 @@ defaults:
       type: "news"
     values:
       layout: "news"
-      title-class: page-title-activemq5
-      type: activemq5
+      title-class: page-title-main
+      type: main
 
 markdown: kramdown
 highlighter: rouge

--- a/src/_news/news-feed.md
+++ b/src/_news/news-feed.md
@@ -2,7 +2,7 @@
 release_date: 2021-08-30
 title: ActiveMQ News Feed
 shortDescription: Checkout the new news feed!
-title-class: page-title-activemq5
-type: activemq5
+title-class: page-title-main
+type: main
 ---
 The ActiveMQ website now has this handy dandy <a href="{{site.baseurl}}/news">news feed</a> where you'll find the latest releases, CVEs, blogs, articles, roadmaps, etc.

--- a/src/news/index.md
+++ b/src/news/index.md
@@ -1,8 +1,8 @@
 ---
 layout: default_md
 title: News 
-title-class: page-title-activemq5
-type: activemq5
+title-class: page-title-main
+type: main
 ---
 
 [Home](/) > [News](/news)


### PR DESCRIPTION
The news feed page doesnt currently match the colour categorisation used in the rest of the site. All the general areas of the site (such as homepage/contact/contribute/etc) use a 'main' type with styling based around green. The components then each have a colouring for specific content (magenta'ish for ActiveMQ 5, purple for Artemis, red for NMS, blue for CMS). These together look to match the component colours used in the logo.

As a general page I think the news feed should be using the 'main' green styling, this changes things so it does. In addition to being consistent I think it looks better because the dates and the links are no longer the same colour as currently, which is confusing to the eye.

Before:
![before](https://user-images.githubusercontent.com/5106823/131848203-249d0f10-7215-407b-a1d1-6abd7c048fc8.png)


After:
![after](https://user-images.githubusercontent.com/5106823/131848258-26e6fbd8-ac10-446d-bc52-0fccb3bd720c.png)