### PR TITLE
ARTEMIS-3524: Resolved breaking links in release-plans page

### DIFF
--- a/src/release-plans.md
+++ b/src/release-plans.md
@@ -10,10 +10,10 @@ type: activemq5
 
 ### Information
 
-*   [Release Info](Release Plans/release-info)
-*   [How you can help release](Release Plans/how-you-can-help-release)
+*   [Release Info](release-info)
+*   [How you can help release](how-you-can-help-release)
 
 ### Release Plans
 
-*   [4.0 RC 1 Guide](Release Plans/40-rc-1-guide)
+*   [4.0 RC 1 Guide](40-rc-1-guide)
 


### PR DESCRIPTION
In the Developers' manual.
https://activemq.apache.org/developers, all kinks on Release Plans page aren't working.  

This PR is to fix this problem
**Issue Link.**  https://issues.apache.org/jira/browse/ARTEMIS-3524

cc @clebertsuconic @brusdev 

Thank you so much