### PR TITLE
Fix table rendering.

### DIFF
--- a/src/discovery-transport-reference.md
+++ b/src/discovery-transport-reference.md
@@ -36,6 +36,7 @@ To configure discovery in a Broker you should use the [Xml Configuration](xml-co
 ```
 
 ##### Transport Options
+
 Option Name|Default Value|Description
 ---|---|---
 reconnectDelay|10|How long to wait for discovery

--- a/src/fanout-transport-reference.md
+++ b/src/fanout-transport-reference.md
@@ -22,11 +22,12 @@ fanout:discoveryURI
 ```
 
 ##### Transport Options
+
 Option Name|Default Value|Description
 ---|---|---
 initialReconnectDelay|10|How long to wait before the first reconnect attempt
 maxReconnectDelay|30000|The maximum amount of time we ever wait between reconnect attempts
-useExponentialBackOff|true|Should an exponential backoff be used btween reconnect attempts
+useExponentialBackOff|true|Should an exponential backoff be used between reconnect attempts
 backOffMultiplier|2|The exponent used in the exponential backoff attempts
 maxReconnectAttempts|0|If not 0, then this is the maximum number of reconnect attempts before an error is sent back to the client
 fanOutQueues|false|If set to 'true', commands are replicated to queues as well as topics


### PR DESCRIPTION
https://activemq.apache.org/fanout-transport-reference and https://activemq.apache.org/discovery-transport-reference.html both have "Transport Options" tables that are not rendered properly because there needs to be an empty line between the header and the table.