### PR TITLE
Fix example config rendering

### DIFF
--- a/src/the-proxy-connector.md
+++ b/src/the-proxy-connector.md
@@ -17,6 +17,7 @@ Many of the more advanced ActiveMQ features are implemented in the transports. S
 
 If you wanted to accept normal connection on port 6001, but also wanted to expose port 6002 which in turn was proxied using the fanout transport, the following example is shows you how to do it!
 
+```
 <beans xmlns="http://activemq.org/config/1.0">
   <broker>
 
@@ -34,4 +35,4 @@ If you wanted to accept normal connection on port 6001, but also wanted to expos
 
   </broker>
 </beans>
-
+```


### PR DESCRIPTION
https://activemq.apache.org/the-proxy-connector is missing the example mentioned. The sample config exists in the markdown file but is not rendered properly. 

![image](https://user-images.githubusercontent.com/7095337/144372480-acce86eb-0ef8-4ba9-8663-edecb7714756.png)
