### PR TITLE
[AMQ-8345] Update JMS2 progress page

### DIFF
--- a/src/jms2.md
+++ b/src/jms2.md
@@ -23,13 +23,16 @@ The implementation approach is subject to change. Be sure to verify features in 
 
 User feedback is welcome! Please comment on the JIRAs with questions and comments.
 
-JIRA|Target Version|Completed Version|Feature|Notes
+JIRA|Status|Target Version|Completed Version|Feature|Notes
 ---|---|---
-[AMQ-7309](https://issues.apache.org/jira/browse/AMQ-7309) | 5.17.0.RC1 | | JMS v2.0 API dependency | ActiveMQ will ship with a JMS v2.0 dependency jar
-[AMQ-8320](https://issues.apache.org/jira/browse/AMQ-8320) | 5.17.0.RC1 | | Delivery Delay | Support for Message DeliveryDelay feature
-[AMQ-8321](https://issues.apache.org/jira/browse/AMQ-8321) | 5.17.0.RC1 | | GetBody/isBodyAssignable | Support for checking body type using a Class<?>
-[AMQ-8322](https://issues.apache.org/jira/browse/AMQ-8322) | TBD | | Connection.createContext | Simplified JMS Context object support
-[AMQ-8323](https://issues.apache.org/jira/browse/AMQ-8323) | TBD | | Session Topic Consumer | Consume messages using a MessageConsumer object (same as Queue)
-[AMQ-8324](https://issues.apache.org/jira/browse/AMQ-8324) | 5.17.0.RC1 | | MessageProducer send methods | Completion Listener and Delivery Delay support
-[AMQ-8325](https://issues.apache.org/jira/browse/AMQ-8325) | TBD | | XA Connection methods | Updated methods when using XA Transactions
+[AMQ-7309](https://issues.apache.org/jira/browse/AMQ-7309) | merged | 5.17.0 | | JMS v2.0 API dependency | ActiveMQ will ship with a JMS v2.0 dependency jar
+[AMQ-8322](https://issues.apache.org/jira/browse/AMQ-8322) | review [PR-729](https://github.com/apache/activemq/pull/729) | 5.17.0 | | JMSContext | Simplified JMS Context object support
+[AMQ-8322](https://issues.apache.org/jira/browse/AMQ-8322) | review [PR-729](https://github.com/apache/activemq/pull/729) | 5.17.0 | | JMSRuntimeException | Convert JMSExceptions to be JMSRuntimeExceptions
+[AMQ-8322](https://issues.apache.org/jira/browse/AMQ-8322) | review [PR-729](https://github.com/apache/activemq/pull/729) | 5.17.0 | | JMSConsumer | Consume messages 
+[AMQ-8322](https://issues.apache.org/jira/browse/AMQ-8322) | review [PR-729](https://github.com/apache/activemq/pull/729) | 5.17.0 | | JMSProducer | Produce messages
+[AMQ-8320](https://issues.apache.org/jira/browse/AMQ-8320) | | 5.17.1 | | Delivery Delay | Support for Message DeliveryDelay feature
+[AMQ-8321](https://issues.apache.org/jira/browse/AMQ-8321) | | 5.17.1 | | GetBody/isBodyAssignable | Support for checking body type using a Class<?>
+[AMQ-8324](https://issues.apache.org/jira/browse/AMQ-8324) | | TBD | | JMSProducer features | Completion Listener and Delivery Delay support
+[AMQ-8325](https://issues.apache.org/jira/browse/AMQ-8325) | | TBD | | XA Connection methods | Updated methods when using XA Transactions
+[AMQ-8323](https://issues.apache.org/jira/browse/AMQ-8323) | | TBD | | Shared Topic Consumer | Multi-consumer (queue-like) consuming from topic subscriptions
 


### PR DESCRIPTION
 - Remove RC notation, as there is no planned "RC"-style release
 - Update tracking based on planned version alignment to JIRA tasks