### PR TITLE
Fix breadcrumb link and spacing in `failover-transport-reference.md`

### DIFF
--- a/src/failover-transport-reference.md
+++ b/src/failover-transport-reference.md
@@ -5,7 +5,7 @@ title-class: page-title-activemq5
 type: activemq5
 ---
 
- [Using ActiveMQ](using-activemq) > [Configuring Transports](configuring-transports)> [ActiveMQ Connection URIs](activemq-connection-uris] > [Failover Transport Reference ](failover-transport-reference)
+[Using ActiveMQ](using-activemq) > [Configuring Transports](configuring-transports) > [ActiveMQ Connection URIs](activemq-connection-uris) > [Failover Transport Reference](failover-transport-reference)
 
 ### The Failover Transport
 


### PR DESCRIPTION
It's a very minor nitpick I happened to bump into 😃 

![image](https://user-images.githubusercontent.com/7294642/165544444-9931ecee-c5a1-4690-9d99-f47adcf36996.png)

![image](https://user-images.githubusercontent.com/7294642/165544628-074f9213-4aa3-4257-a794-9106f86064fe.png)
