### PR TITLE
LDAPLoginModule does not support debug option so don't set it in example

### DIFF
--- a/src/security.md
+++ b/src/security.md
@@ -170,7 +170,6 @@ A new/better ldap authorization module is available since 5.6. See [Cached LDAP 
     ```
     LdapConfiguration { 
        org.apache.activemq.jaas.LDAPLoginModule required 
-       debug=true 
        initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory 
        connectionURL="ldap://ldap.acme.com:389" 
        connectionUsername="cn=mqbroker,ou=Services,dc=acme,dc=com" 


### PR DESCRIPTION
Guess it is due to a copy paste in the project from other login modules supporting it and the doc just copied the project login.config (for tests).