### PR TITLE
Fix news feed formatting and recent release notes headers

### DIFF
--- a/src/_includes/news.md
+++ b/src/_includes/news.md
@@ -1,7 +1,7 @@
 {% assign releases = site.documents %} {% assign releases = releases | sort: "release_date" | reverse %}
  <div class="row align-middle">
 {% assign i = 0 %}
-<div class="card-group">
+<div class="card-group w-100">
 {% for release in releases %} {% if i > 2 %} {% break %} {% endif %}
 <div class="card card-grey-small">
 <div class="card-body ml-0 p-2">

--- a/src/components/artemis/download/release-notes-2.23.0.md
+++ b/src/components/artemis/download/release-notes-2.23.0.md
@@ -11,7 +11,7 @@ A list of commits can be found  * [here](commit-report-2.23.0).
 
 **Note**: This release requires use of Java 11 or above.
 
-#Bug
+# Bug
  * [ARTEMIS-3376] - help text for "artemis address --no-anycast/--no-multicast" is incorrect
  * [ARTEMIS-3810] - XID Resumes on already Active Transactions should not throw any error
  * [ARTEMIS-3811] - QueueBinding type will clash with cluster connections
@@ -27,11 +27,11 @@ A list of commits can be found  * [here](commit-report-2.23.0).
  * [ARTEMIS-3848] - High cpu usage on ReadWrite locks
  * [ARTEMIS-3853] - Ping command for IPv6 is wrong on Windows
  
-#New Feature
+# New Feature
  * [ARTEMIS-3700] - Provide JakartaEE 10 artefacts and support
  * [ARTEMIS-3817] - Management schedulePageCleanup operation on AddressControl
 
-#Improvement
+# Improvement
  * [ARTEMIS-3759] - Allow for Mirroring (Broker Connections) to specify a specific set of addresses to send events, as is done for a cluster connection
  * [ARTEMIS-3770] - Refactor MQTT handling of client ID
  * [ARTEMIS-3807] - Simplify Message Redistributor avoiding races
@@ -41,7 +41,7 @@ A list of commits can be found  * [here](commit-report-2.23.0).
  * [ARTEMIS-3825] - Improve print-data to recognize queues that do not exist
  * [ARTEMIS-3835] - Deprecate addressesSettings configuration attribute with double plural in place of addressSettings
 
-#Dependency upgrade
+# Dependency upgrade
  * [ARTEMIS-3806] - Upgrade logging dependencies
  * [ARTEMIS-3812] - Upgrade Micrometer
  * [ARTEMIS-3814] - Update to ActiveMQ 5.17.1

--- a/src/components/artemis/download/release-notes-2.23.1.md
+++ b/src/components/artemis/download/release-notes-2.23.1.md
@@ -11,12 +11,12 @@ A list of commits can be found  * [here](commit-report-2.23.1).
 
 **Note**: This release requires use of Java 11 or above.
 
-#Bug
+# Bug
  * [ARTEMIS-3305] - compatibility tests dont work on Java 16+
  * [ARTEMIS-3856] - Failed to change channel state to ReadyForWriting : java.util.ConcurrentModificationException
 
-#Test
+# Test
  * [ARTEMIS-3854] - tests using reflection to get process pid fail on Java 17
 
-#Task
+# Task
  * [ARTEMIS-3842] - artemis-selector module still references a JDK8


### PR DESCRIPTION
Fixing two little issues that I noticed. 1/ The news feed on the main page doesn't take up the full width for some reason, and 2/ the latest Artemis release notes don't render the headings properly. 

Main page before: 
<img width="1532" alt="image" src="https://user-images.githubusercontent.com/7095337/175512176-035e8bbc-66e5-4d44-8754-bd1db4001b13.png">

Main page after: 
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/7095337/175512459-94690348-e40a-4a0a-9646-38826dc93dcc.png">

Artemis release notes before: 
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/7095337/175512241-55c45595-5e75-42f8-94e8-9cc66a2c0d43.png">

Artemis release notes after: 
<img width="1532" alt="image" src="https://user-images.githubusercontent.com/7095337/175512385-33f3782b-28bb-4216-aedd-725bbd5bed06.png">
