### PR TITLE
Fix links in release notes for 5.15.2 to 5.15.9

### DIFF
--- a/src/_5x_releases/activemq-5015002-release.md
+++ b/src/_5x_releases/activemq-5015002-release.md
@@ -93,4 +93,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.1 Release](activemq-5151-release)

--- a/src/_5x_releases/activemq-5015003-release.md
+++ b/src/_5x_releases/activemq-5015003-release.md
@@ -85,7 +85,7 @@ Source Release|[activemq-parent-5.15.3-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341947)
 
 > **Java 8 Required**
 > 
@@ -93,4 +93,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.2 Release](activemq-5152-release)

--- a/src/_5x_releases/activemq-5015004-release.md
+++ b/src/_5x_releases/activemq-5015004-release.md
@@ -85,7 +85,7 @@ Source Release|[activemq-parent-5.15.4-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12342685)
 
 > **Java 8 Required**
 > 
@@ -93,4 +93,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.3 Release](activemq-5153-release)

--- a/src/_5x_releases/activemq-5015005-release.md
+++ b/src/_5x_releases/activemq-5015005-release.md
@@ -85,7 +85,7 @@ Source Release|[activemq-parent-5.15.5-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12343307)
 
 > **Java 8 Required**
 > 
@@ -93,4 +93,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.4 Release](activemq-5154-release)

--- a/src/_5x_releases/activemq-5015006-release.md
+++ b/src/_5x_releases/activemq-5015006-release.md
@@ -87,7 +87,7 @@ Source Release|[activemq-parent-5.15.6-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12343805)
 
 > **Java 8 Required**
 > 
@@ -95,4 +95,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.5 Release](activemq-5155-release)

--- a/src/_5x_releases/activemq-5015007-release.md
+++ b/src/_5x_releases/activemq-5015007-release.md
@@ -87,7 +87,7 @@ Source Release|[activemq-parent-5.15.7-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12344049)
 
 > **Java 8 Required**
 > 
@@ -95,4 +95,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.6 Release](activemq-5156-release)

--- a/src/_5x_releases/activemq-5015008-release.md
+++ b/src/_5x_releases/activemq-5015008-release.md
@@ -87,7 +87,7 @@ Source Release|[activemq-parent-5.15.8-source-release.zip](https://archive.apach
 Change Log
 ----------
 
-For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341669)
+For a more detailed view of new features and bug fixes, see the [release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12344359)
 
 > **Java 8 Required**
 > 
@@ -95,4 +95,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.7 Release](activemq-5157-release)

--- a/src/_5x_releases/activemq-5015009-release.md
+++ b/src/_5x_releases/activemq-5015009-release.md
@@ -95,4 +95,4 @@ For a more detailed view of new features and bug fixes, see the [release notes]
 
 > This release affects applications using ObjectMessages. Please refer to [objectmessage](objectmessage) and jira-issue [AMQ-6013](https://issues.apache.org/jira/browse/AMQ-6013) for more information.
 
-Also see the previous [ActiveMQ 5.15.0 Release](activemq-5150-release)
+Also see the previous [ActiveMQ 5.15.8 Release](activemq-5158-release)


### PR DESCRIPTION
The release notes for release 5.15.3 until 5.15.8 had links to jira generated release notes for 5.15.2.
The release notes for release 5.15.2 until 5.15.9 referensed 5.15.0 as the previous release.