### PR TITLE
Apache.NMS.ActiveMQ 2.0.1 Release

### DIFF
--- a/src/_nms_activemq_releases/apachenmsactivemq-v201.md
+++ b/src/_nms_activemq_releases/apachenmsactivemq-v201.md
@@ -1,0 +1,24 @@
+---
+layout: default_md
+title-class: page-title-nms
+type: nms
+version: 2.0.1
+release_date: 2023-02-14
+release_notes: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311201&version=12352889
+title: Apache.NMS.ActiveMQ 2.0.1 Release
+# The shortDescription is used on front page news entry and news feed pages
+shortDescription: Deadlock fix in WinForms environment.
+---
+
+Apache NMS.ActiveMQ {{ page.version }} was released on {{ page.release_date | date_to_string: "ordinal", "US" }}. This release contains a single bug fix.
+
+Download Here
+-------------
+
+Apache.NMS.ActiveMQ Source code|[Apache.NMS.ActiveMQ-2.0.1-src.zip ](https://www.apache.org/dyn/closer.lua?filename=/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-src.zip&action=download)|[SHA512](https://downloads.apache.org/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-src.zip.sha512)|[PGP Signature](https://downloads.apache.org/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-src.zip.asc)
+Apache.NMS.ActiveMQ Binary Assemblies|[Apache.NMS.ActiveMQ-2.0.1-bin.zip](https://www.apache.org/dyn/closer.lua?filename=/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-bin.zip&action=download)|[SHA512](https://downloads.apache.org/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-bin.zip.sha512)|[PGP Signature](https://downloads.apache.org/activemq/apache-nms-activemq/2.0.1/Apache.NMS.ActiveMQ-2.0.1-bin.zip.asc)
+
+Changelog
+---------
+
+For a more detailed view of new features and bug fixes, see the [release notes]({{ page.release_notes }}).


### PR DESCRIPTION
@gemmellr would be so kind to check if it's ok according to the new best practices? 

I followed the instructions in the read.me and tried to run this locally, but I'm getting the following error on attempt to execute `build.sh`.

```
/Library/Ruby/Site/2.6.0/rubygems.rb:263:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
	from /Library/Ruby/Site/2.6.0/rubygems.rb:282:in `activate_bin_path'
	from /usr/bin/bundle:23:in `<main>
```

My env:
- macOS 13.2 (22D49) (m1)
- ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin22]


