### PR TITLE
[AMQ-9303] Fix the link to the configuration FAQ

### DIFF
--- a/src/getting-started-3x.md
+++ b/src/getting-started-3x.md
@@ -290,7 +290,7 @@ See the [Initial Configuration](Using ActiveMQ/initial-Community/FAQ/configurati
 
 If you want to use JNDI to connect to your JMS provider then please view the [JNDI Support](Connectivity/Containers/jndi-Community/support.md "JNDI Support"). If you are a Spring user you should read about [Spring Support](Connectivity/Containers/spring-Community/support.md "Spring Support")
 
-After the installation, ActiveMQ is running with a basic configuration. For details on configuring options, please see refer to the [Configuration](Community/FAQ/configuration.md "Configuration") section.
+After the installation, ActiveMQ is running with a basic configuration. For details on configuring options, please refer to the [Configuration](Community/FAQ/configuration.md "Configuration") section.
 
 Additional Resources
 --------------------

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -347,7 +347,7 @@ See the [Initial Configuration](configuration) for details of which jars you nee
 
 If you want to use JNDI to connect to your JMS provider then please view the [JNDI Support](jndi-support). If you are a Spring user you should read about [Spring Support](spring-support)
 
-After the installation, ActiveMQ is running with a basic configuration. For details on configuring options, please see refer to the [Configuration](configuration) section.
+After the installation, ActiveMQ is running with a basic configuration. For details on configuring options, please refer to the [Configuration](faq#configuration) section.
 
 Additional Resources
 --------------------


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/AMQ-9303

## Motivation

The link to the configuration FAQ is broken in the Getting Started guide

## Modifications

* Fix the link to refer to the configuration FAQ [like it was in the past](https://github.com/apache/activemq-website/blob/6aba7c4977b14ca2263a8c4cb7cd64f55cb3b89b/configuration.md)
* Fix a small typo in the same sentence