### PR TITLE
Remove flavor section as it's confusing for users and not actually accurate

### DIFF
--- a/src/components/classic/documentation/activemq-artemis-roadmap.md
+++ b/src/components/classic/documentation/activemq-artemis-roadmap.md
@@ -5,13 +5,13 @@ title-class: page-title-main
 type: main
 ---
 
-The goal of this page is to identify the outstanding issues that must be addressed by Artemis in order to achieve feature parity with Classic. The overall objective for working toward feature parity between Classic and Artemis is for Artemis to eventually become the next major version of ActiveMQ. This page exists so that we can work together as a group to achieve this goal. This page does **not** list the features which Artemis has *beyond* what currently exists in Classic.
+The goal of this page is to identify the outstanding issues that must be addressed by Artemis in order to achieve feature parity with ActiveMQ Classic. This page does **not** list the features which Artemis has *beyond* what currently exists in Classic.
 
 ## Features/Scenarios
 
 This section should be used to compare what features from ActiveMQ Classic have been implemented in Artemis. Feature items can be listed, with links to JIRA tickets for longer conversation and hashing out specific feature details. This will help us to more clearly track everything that Artemis needs. This list of features was taken from the Classic [features page](features).
 
-Keep in mind that not every feature must have a &#9989;. Artemis may still be ready to become ActiveMQ *Next* even if features on this page still have an &#10060; if those features are deemed low priority. Artemis is not meant to be a 100% complete reimplementation of ActiveMQ Classic. Features should only be reimplemented where it makes good sense.
+Keep in mind that not every feature must have a &#9989;. Artemis is not meant to be a 100% complete reimplementation of ActiveMQ Classic. Features should only be reimplemented where it makes good sense.
 
 ### Protocol Support
 

--- a/src/components/classic/documentation/how-does-classic-compare-to-artemis.md
+++ b/src/components/classic/documentation/how-does-classic-compare-to-artemis.md
@@ -10,4 +10,4 @@ type: classic
 
 [Artemis](../../../components/artemis) is the codename used for the HornetQ code that was donated to the Apache Foundation.
 
-Artemis may eventually become the successor to Classic 6.x/5.x. Classic 6.x is a modernization of Classic 5.x with support for Jakarta EE.
+It's a complete broker, similar to ActiveMQ Classic.

--- a/src/index.html
+++ b/src/index.html
@@ -34,20 +34,6 @@ layout: default
 
 {% include news.md %}
 
-  <!-- General info -->
-<div class="row d-none d-lg-block">
-  <div class="col-sm-12 narative">
-    <div class="card">
-      <div class="card-body narative">
-          <span>
-            <p>There are currently two "flavors" of ActiveMQ available - the well-known "classic" broker and the "next generation" broker code-named <i>Artemis</i>. Once Artemis reaches a sufficient level of feature parity with the "Classic" code-base it will become the next major version of ActiveMQ. Initial <a href="{{site.baseurl}}/components/artemis/migration">migration documentation</a> is available as well as a development <a href="{{site.baseurl}}/activemq-artemis-roadmap">roadmap</a> for Artemis.</p>
-          </span>
-      </div>
-    </div>
-  </div>
-</div>
-
-
 <!-- Components -->
 <div class="row align-middle">
   <div class="col-lg-6 col-md-auto">
@@ -56,7 +42,7 @@ layout: default
         <h4 class="card-title text-pink">ActiveMQ Classic</h4>
         <p>Long established, endlessly pluggable architecture serving many generations of applications.</p>
         <ul>
-          <li>Jakarta 3.1, JMS 2.0, and JMS 1.1 with full client implementation including JNDI</li>
+          <li>Jakarta Messaging 3.1, JMS 2.0, and JMS 1.1 with full client implementation including JNDI</li>
           <li>High availability using shared storage</li>
           <li>Familiar JMS-based addressing model</li>
           <li>Network of brokers for distributing load</li>


### PR DESCRIPTION
We have two subprojects on the ActiveMQ TLP, each with release cycle, roadmap, ...

Users are confused with this statement. I propose to remove it.
Users can evaluate themselves and decide to use one or another as both are still maintained.

@jbertram @cshannon @mattrpav wdyt ?