### PR TITLE
Correct rewrite rule for classic download 

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -120,7 +120,7 @@ RewriteRule ^does-activemq-support-my-sql-database(.*) https://activemq.apache.o
 RewriteRule ^dot-net(.*) https://activemq.apache.org/components/classic/documentation/dot-net [R=301,L]
 RewriteRule ^download-archives(.*) https://activemq.apache.org/components/classic/documentation/download-archives [R=301,L]
 RewriteRule ^downloading-activemq-cpp(.*) https://activemq.apache.org/components/classic/documentation/downloading-activemq-cpp [R=301,L]
-RewriteRule ^download(.*) https://activemq.apache.org/components/classic/documentation/download [R=301,L]
+RewriteRule ^download(.*) https://activemq.apache.org/components/classic/download [R=301,L]
 RewriteRule ^dr(.*) https://activemq.apache.org/components/classic/documentation/dr [R=301,L]
 RewriteRule ^durable-queue-memory-management(.*) https://activemq.apache.org/components/classic/documentation/durable-queue-memory-management [R=301,L]
 RewriteRule ^enable-openssl-support-with-autotools(.*) https://activemq.apache.org/components/classic/documentation/enable-openssl-support-with-autotools [R=301,L]


### PR DESCRIPTION
The download link from ActiveMQ Web Console does not work (Under Useful Links). 
Downloads goes http://activemq.apache.org/download.html which gets redirected to https://activemq.apache.org/components/classic/documentation/download that does not exist. Correct it to point to https://activemq.apache.org/components/classic/download