### PR TITLE
fix incorrect links in the classic/documentation/restful-queue

### DIFF
--- a/src/components/classic/documentation/restful-queue.md
+++ b/src/components/classic/documentation/restful-queue.md
@@ -13,9 +13,9 @@ RESTful Queue
 
 This document is intended to document the ideal RESTful interface to message queues in light of
 
-*   [the discussion on rest-discuss](http://tech.groups.yahoo.com/group/rest-discuss/message/8955)
+*   [the discussion on rest-discuss](https://lists.apache.org/thread/nyt363l2z3lmnyd6239wykr0dvxhx739)
 *   [Atom Publishing Protocol](http://bitworking.org/projects/atom/draft-ietf-atompub-protocol-17.html) (APP)
-*   [httplr](http://www.dehora.net/doc/httplr/draft-httplr-01.html)
+*   [httplr](https://blog.sethladd.com/2005/04/http-reliable-messaging.html)
 
 ### Issues with Queues and REST
 


### PR DESCRIPTION
The links in the https://activemq.apache.org/components/classic/documentation/restful-queue lead nowhere:

* [the discussion on rest-discuss](http://tech.groups.yahoo.com/group/rest-discuss/message/8955)
* [httplr](http://www.dehora.net/doc/httplr/draft-httplr-01.html)

```
This site can’t be reachedtech.groups.yahoo.com’s server IP address could not be found.
```

```
We couldn't find the page you were looking for. 
```

I updated the links so that readers can get the info about `httplr` and `discussion on rest` faster.