### PR TITLE
Add documentation for docker image of ActiveMQ classic

### DIFF
--- a/src/components/classic/documentation/docker-image.md
+++ b/src/components/classic/documentation/docker-image.md
@@ -1,0 +1,19 @@
+---
+layout: default_md
+title: Using ActiveMQ Classic with Docker
+title-class: page-title-classic
+type: classic
+---
+
+You can also get started with ActiveMQ Classic Docker image in no time. The image is hosted [here](https://hub.docker.com/r/apache/activemq-classic/tags)
+
+Step 1. Pull the image
+```
+docker pull apache/activemq-classic:latest
+```
+
+Step 2. Run the image
+```
+docker run -p 61616:61616 -p 8161:8161 apache/activemq-classic:latest 
+```
+Note: Make sure you expose the correct port using `-p`. The command above only expose port 8161 for the web console and port 61616 for the Openwire connection

--- a/src/components/classic/documentation/getting-started.md
+++ b/src/components/classic/documentation/getting-started.md
@@ -39,6 +39,7 @@ The Getting Started Guide for ActiveMQ Classic 5.x document contains the followi
 *   [Stopping ActiveMQ Classic](#StoppingActiveMQClassic)
 *   [Configuring ActiveMQ Classic](#ConfiguringActiveMQClassic)
 *   [Additional Resources](#AdditionalResources)
+*   [Docker Image](docker-image)
 
 Pre-Installation Requirements
 -----------------------------


### PR DESCRIPTION
This can be redirected from Getting Started guide. 

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/04438a89-83d4-4c46-a26a-cb07a9a17efe">

