### PR TITLE
Update ActiveMQ Classic download page

### DIFF
--- a/src/components/classic/download/index.md
+++ b/src/components/classic/download/index.md
@@ -9,22 +9,128 @@ These are the current ActiveMQ Classic releases. For prior releases, please see 
 
 It is important to [verify the integrity](#verify-the-integrity-of-downloads) of the files you download.
 
+#### Summary Table of ActiveMQ Series Status
+
+
+<table>
+  <thead>
+    <tr>
+      <th>Series</th>
+      <th>Status</th>
+      <th>Latest Patch Version</th>
+      <th>Date of Release</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr style="background-color: #dff0d8;">
+      <td>6.2.x</td>
+      <td>In Dev</td>
+      <td>-</td>
+      <td></td>
+    </tr>
+    <tr style="background-color: #dff0d8;">
+      <td>6.1.x</td>
+      <td><strong>Stable - Supported</strong></td>
+      <td>6.1.3</td>
+      <td>Aug 8th, 2024</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>6.0.x</td>
+      <td><em>Deprecated</em></td>
+      <td>6.0.1</td>
+      <td>Dec 3rd, 2023</td>
+    </tr>
+    <tr style="background-color: #dff0d8;">
+      <td>5.18.x</td>
+      <td><strong>Stable - Supported</strong></td>
+      <td>5.18.6</td>
+      <td>Oct 2nd, 2024</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.17.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.17.6</td>
+      <td>Oct 25th, 2023</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.16.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.16.7</td>
+      <td>Oct 26th, 2023</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.15.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.15.16</td>
+      <td>Oct 26th, 2023</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.14.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.14.5</td>
+      <td>Apr 25th, 2017</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.13.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.13.5</td>
+      <td>Dec 16th, 2016</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.12.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.12.3</td>
+      <td>Feb 3rd, 2016</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.11.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.11.4</td>
+      <td>Feb 3rd, 2016</td>
+    </tr>
+    <tr style="background-color: #f0f0f0;">
+      <td>5.10.x</td>
+      <td><em>Deprecated</em></td>
+      <td>5.10.2</td>
+      <td>Feb 13th, 2016</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+##### Status Descriptions
+
+<div style="margin-top: 15px;">
+  <strong>In Dev</strong>: Actively in development with new features and improvements in progress. This version may not yet be fully stable for production environments.
+</div>
+
+<div style="margin-top: 10px;">
+  <strong>Stable - Supported</strong>: Actively supported and recommended for production use. This version receives regular updates, including new features, security patches, and bug fixes.
+</div>
+
+<div style="margin-top: 10px;">
+  <strong>Deprecated</strong>: Reached end-of-life and is no longer maintained. Deprecated versions do not receive updates. Not recommended for new deployments; users are encouraged to upgrade to a stable version for ongoing support.
+</div>
+
+
+
 #### Schedule & Status
 
 | Series | Broker JMS API Support      | Client JMS API Client       | Java Version | Spring Version | Logging Support              | Web Support            | Status       | Last    | Next   | ETA     |
 |--------|-----------------------------|-----------------------------|--------------|----------------|------------------------------|------------------------|--------------|---------|--------|---------|
 | 6.2.x  | Jakarta JMS 2/3.1 (partial) | Jakarta JMS 2/3.1           | 17+          | 6.1.11         | Log4j 2.23.1/Slf4j 2.0.13    | Jetty 11.0.22          | In dev       |         |        | Nov  24 |
-| 6.1.x  | Jakarta JMS 2/3.1 (partial) | Jakarta JMS 2/3.1           | 17+          | 6.1.11         | Log4j 2.23.1/Slf4j 2.0.13    | Jetty 11.0.22          | **Stable**   | 6.1.3   | 6.1.4  | Nov  24 |
+| 6.1.x  | Jakarta JMS 2/3.1 (partial) | Jakarta JMS 2/3.1           | 17+          | 6.1.11         | Log4j 2.23.1/Slf4j 2.0.13    | Jetty 11.0.22          | **Stable - Supported**   | 6.1.3   | 6.1.4  | Nov  24 |
 | 6.0.x  | Jakarta JMS 2/3.1 (partial) | Jakarta JMS 2/3.1           | 17+          | 6.0.17         | Log4j 2.22.0/Slf4j 2.0.9     | Jetty 11.0.18          | _Not Active_ | 6.0.1   |        |         |
-| 5.18.x | Javax JMS 1.1               | Javax JMS 1.1/Jakarta JMS 2 | 11+          | 5.3.39         | Log4j 2.23.1/Slf4j 2.0.13    | Jetty 9.4.56.v20240826 | **Stable**   | 5.18.6  | 5.18.7 | Dec  24 |
-| 5.17.x | Javax JMS 1.1               | Javax JMS 1.1               | 11+          | 5.3.30         | Log4j 2.20.0/Slf4j 1.7.36    | Jetty 9.4.53.v20231009 | _Not Active_ | 5.17.6  |        |         |
-| 5.16.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.8          | 4.3.30.RELEASE | Reload4j 1.2.24/Slf4j 1.7.26 | Jetty 9.4.50.v20221201 | _Not Active_ | 5.16.7  |        |         |
-| 5.15.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.8          | 4.3.30.RELEASE | Log4j 1.2.17/Slf4j 1.7.32    | Jetty 9.4.39.v20210325 | _Not Active_ | 5.15.16 |        |         |
-| 5.14.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 4.1.9.RELEASE  | Log4j 1.2.17/Slf4j 1.7.13    | Jetty 9.2.13.v20150730 | _Not Active_ | 5.14.5  |        |         |
-| 5.13.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 4.1.9.RELEASE  | Log4j 1.2.17/Slf4j 1.7.13    | Jetty 9.2.13.v20150730 | _Not Active_ | 5.13.5  |        |         |
-| 5.12.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 3.2.16.RELEASE | Log4j 1.2.17/Slf4j 1.7.10    | Jetty 9.2.6.v20141205  | _Not Active_ | 5.12.3  |        |         |
-| 5.11.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 3.2.16.RELEASE | Log4j 1.2.17/Slf4j 1.7.10    | Jetty 9.2.6.v20141205  | _Not Active_ | 5.11.4  |        |         |
-| 5.10.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.6          | 3.2.8.RELEASE  | Log4j 1.2.17/Slf4j 1.7.5     | Jetty 7.6.9.v20130131  | _Not Active_ | 5.10.2  |        |         |
+| 5.18.x | Javax JMS 1.1               | Javax JMS 1.1/Jakarta JMS 2 | 11+          | 5.3.39         | Log4j 2.23.1/Slf4j 2.0.13    | Jetty 9.4.56.v20240826 | **Stable - Supported**   | 5.18.6  | 5.18.7 | Dec  24 |
+| 5.17.x | Javax JMS 1.1               | Javax JMS 1.1               | 11+          | 5.3.30         | Log4j 2.20.0/Slf4j 1.7.36    | Jetty 9.4.53.v20231009 | _Deprecated_ | 5.17.6  |        |         |
+| 5.16.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.8          | 4.3.30.RELEASE | Reload4j 1.2.24/Slf4j 1.7.26 | Jetty 9.4.50.v20221201 | _Deprecated_ | 5.16.7  |        |         |
+| 5.15.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.8          | 4.3.30.RELEASE | Log4j 1.2.17/Slf4j 1.7.32    | Jetty 9.4.39.v20210325 | _Deprecated_ | 5.15.16 |        |         |
+| 5.14.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 4.1.9.RELEASE  | Log4j 1.2.17/Slf4j 1.7.13    | Jetty 9.2.13.v20150730 | _Deprecated_ | 5.14.5  |        |         |
+| 5.13.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 4.1.9.RELEASE  | Log4j 1.2.17/Slf4j 1.7.13    | Jetty 9.2.13.v20150730 | _Deprecated_ | 5.13.5  |        |         |
+| 5.12.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 3.2.16.RELEASE | Log4j 1.2.17/Slf4j 1.7.10    | Jetty 9.2.6.v20141205  | _Deprecated_ | 5.12.3  |        |         |
+| 5.11.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.7          | 3.2.16.RELEASE | Log4j 1.2.17/Slf4j 1.7.10    | Jetty 9.2.6.v20141205  | _Deprecated_ | 5.11.4  |        |         |
+| 5.10.x | Javax JMS 1.1               | Javax JMS 1.1               | 1.6          | 3.2.8.RELEASE  | Log4j 1.2.17/Slf4j 1.7.5     | Jetty 7.6.9.v20130131  | _Deprecated_ | 5.10.2  |        |         |
 
 {% assign reversed_releases = site["classic_releases"] | reverse %}
 


### PR DESCRIPTION
This change introduces a new summary table that describes the ActiveMQ Classic versions and their support statuses, enhancing the page’s readability. Users can now easily identify which versions of ActiveMQ Classic are still supported and which are deprecated