### PR TITLE
Fix: Replace -Dtest=false with -DskipTests to correctly skip tests in Maven build

### DIFF
--- a/src/components/classic/documentation/building.md
+++ b/src/components/classic/documentation/building.md
@@ -30,7 +30,7 @@ ActiveMQ Classic uses Maven 3 to Build. We recommend you download and install [M
 
 ### Doing a Quick Build
 ```
-mvn -Dtest=false -DfailIfNoTests=false clean install 
+mvn -DskipTests -DfailIfNoTests=false clean install 
 ```
 ### Using an IDE
 


### PR DESCRIPTION
### Description
This PR corrects the Maven build configuration by replacing the incorrect usage of -Dtest=false with -DskipTests.

#### What was wrong:
* -`Dtest=false` tells Maven's Surefire plugin to run a test class literally named "false", which leads to the error:

> No tests matching pattern "false" were executed!
