### PR TITLE
Fix typo in FAQ: correct “resouce” to “resource”

### DIFF
--- a/src/components/classic/documentation/what-happens-with-a-fast-producer-and-slow-consumer.md
+++ b/src/components/classic/documentation/what-happens-with-a-fast-producer-and-slow-consumer.md
@@ -10,5 +10,5 @@ type: classic
 
 It depends a little on the [QoS](qos) but in general we implement _flow control_ which means that when we have a very fast producer and a slow consumer, when we get to a high water mark of outstanding messages we will start to tell the producer to slow down (which occurs inside the JMS client automatically, no application code changes are required). The slow down messages will increase exponentially over time until things get back into balance again.
 
-Flow control avoids unnecessary resouce exhaustion and is particularly useful in non-durable messaging modes to avoid running out of memory / disk on a node.
+Flow control avoids unnecessary resource exhaustion and is particularly useful in non-durable messaging modes to avoid running out of memory / disk on a node.
 


### PR DESCRIPTION
The Apache ActiveMQ Classic FAQ page “What happens with a fast producer and slow consumer” contained a spelling error in the flow control description. The phrase “resouce exhaustion” has been corrected to “resource exhaustion” to improve clarity and accuracy.